### PR TITLE
商品一覧表示（サーバーサイド）

### DIFF
--- a/app/assets/stylesheets/modules/_main.scss
+++ b/app/assets/stylesheets/modules/_main.scss
@@ -252,10 +252,11 @@
       }
     }
     .productlists{
-      width: 780px;
+      width: 1165px;
       margin: 26px auto;
       display: flex;
-      justify-content: center;
+      justify-content: start;
+      flex-wrap: wrap;
       .PurchasedProducts {
         position: relative;
         .SoldOutMsg {
@@ -357,10 +358,11 @@
       }
     }
     .productlists{
-      width: 780px;
+      width: 1165px;
       margin: 26px auto;
       display: flex;
-      justify-content: center;
+      justify-content: start;
+      flex-wrap: wrap;
       .PurchasedProducts {
         position: relative;
         .SoldOutMsg {

--- a/app/assets/stylesheets/modules/_main.scss
+++ b/app/assets/stylesheets/modules/_main.scss
@@ -256,6 +256,48 @@
       margin: 26px auto;
       display: flex;
       justify-content: center;
+      .PurchasedProducts {
+        position: relative;
+        .SoldOutMsg {
+          width: 200px;
+          height: 30px;
+          text-align: center;
+          font-weight: bold;
+          font-size: 30px;
+          color: #FF0000;
+          position: absolute;
+          top: 57px;
+          left: 16px;
+        }
+        .Product {
+          width: 233px;
+          height: 245px;
+          text-decoration: none;
+          background-color: #fff;
+          opacity: 0.3;
+          .ItemImage {
+            width: 233px;
+            height: 150px;
+          }
+          .ItemDetail {
+            padding: 16px;
+            color: #333;
+            background-color: white;
+            &__Details {
+              margin-top: 3px;
+              font-weight: bold;
+              display: flex;
+              justify-content: space-between;
+              .Price {
+                font-family: Arial;
+                p {
+                  font-size: 10px;
+                }
+              }
+            }
+          }
+        }
+      }
       .Products {
         .Product {
           width: 233px;
@@ -319,6 +361,48 @@
       margin: 26px auto;
       display: flex;
       justify-content: center;
+      .PurchasedProducts {
+        position: relative;
+        .SoldOutMsg {
+          width: 200px;
+          height: 30px;
+          text-align: center;
+          font-weight: bold;
+          font-size: 30px;
+          color: #FF0000;
+          position: absolute;
+          top: 57px;
+          left: 16px;
+        }
+        .Product {
+          width: 233px;
+          height: 245px;
+          text-decoration: none;
+          background-color: #fff;
+          opacity: 0.3;
+          .ItemImage {
+            width: 233px;
+            height: 150px;
+          }
+          .ItemDetail {
+            padding: 16px;
+            color: #333;
+            background-color: white;
+            &__Details {
+              margin-top: 3px;
+              font-weight: bold;
+              display: flex;
+              justify-content: space-between;
+              .Price {
+                font-family: Arial;
+                p {
+                  font-size: 10px;
+                }
+              }
+            }
+          }
+        }
+      }
       .Products {
         .Product {
           width: 233px;

--- a/app/assets/stylesheets/modules/_products.scss
+++ b/app/assets/stylesheets/modules/_products.scss
@@ -161,6 +161,22 @@
           display: block;
         }
       }
+      .SoldOutBox {
+        margin-top: 10px;
+        padding: 25px 0px;
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+        background-color: #fff;
+        &__Msg {
+        width: 650px;
+        padding: 13px 0px;
+        text-align: center;
+        border-radius: 5px;
+        color: honeydew;
+        background-color: grey;
+        }
+      }
       .CommentBox {
         margin-top: 10px;
         padding: 25px 0px;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -14,6 +14,7 @@ class ProductsController < ApplicationController
     @categories = @product.categories
     @product_image = ProductImage.find_by(product_id: params[:id])
     @product_images = ProductImage.all.where(product_id: params[:id])
+    @purchase_history = PurchaseHistory.find_by(product_id: params[:id])
   end
 
   def destroy

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,6 +3,7 @@ class ProductsController < ApplicationController
   def index
     @products = Product.all
     @product_images = ProductImage.all
+    @purchase_history = PurchaseHistory.all
   end
 
   def new

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -5,6 +5,7 @@ class Product < ApplicationRecord
   has_many :product_images, dependent: :destroy
   has_many :product_categories, dependent: :destroy
   has_many :categories, through: :product_categories
+  has_one :purchase_history
 
   mount_uploader :product_image, ImageUploader
 

--- a/app/models/purchase_history.rb
+++ b/app/models/purchase_history.rb
@@ -1,0 +1,3 @@
+class PurchaseHistory < ApplicationRecord
+  has_one :product
+end

--- a/app/views/products/_main.html.haml
+++ b/app/views/products/_main.html.haml
@@ -72,6 +72,64 @@
         %h3.title 新規投稿商品
     .productlists
       - @products.each do |product|
+        - if @purchase_history.find_by(product_id: product.id)
+          .PurchasedProducts
+            .SoldOutMsg
+              SOLD OUT
+            = link_to product_path(product.id), class: 'Product' do
+              = image_tag @product_images.find_by(product_id: product.id).image, class: 'ItemImage'
+              .ItemDetail
+                .ItemDetail__Name
+                  %h3
+                    = product.name
+                .ItemDetail__Details
+                  .Price
+                    = product.price
+                    %p (税込)
+                  .Favorites
+                    = icon('fas', 'star')
+                    1
+        - else
+          .Products
+            = link_to product_path(product.id), class: 'Product' do
+              = image_tag @product_images.find_by(product_id: product.id).image, class: 'ItemImage'
+              .ItemDetail
+                .ItemDetail__Name
+                  %h3
+                    = product.name
+                .ItemDetail__Details
+                  .Price
+                    = product.price
+                    %p (税込)
+                  .Favorites
+                    = icon('fas', 'star')
+                    1
+%section.productbrnd
+  %h2.kategorihead ピックアップブランド
+  .productbox
+    .productboxhead
+      = link_to "#" do
+        %h3.title アーカイバ
+  .productlists
+    - @products.each do |product|
+      - if @purchase_history.find_by(product_id: product.id)
+        .PurchasedProducts
+          .SoldOutMsg
+            SOLD OUT
+          = link_to product_path(product.id), class: 'Product' do
+            = image_tag @product_images.find_by(product_id: product.id).image, class: 'ItemImage'
+            .ItemDetail
+              .ItemDetail__Name
+                %h3
+                  = product.name
+              .ItemDetail__Details
+                .Price
+                  = product.price
+                  %p (税込)
+                .Favorites
+                  = icon('fas', 'star')
+                  1
+      - else
         .Products
           = link_to product_path(product.id), class: 'Product' do
             = image_tag @product_images.find_by(product_id: product.id).image, class: 'ItemImage'
@@ -86,25 +144,3 @@
                 .Favorites
                   = icon('fas', 'star')
                   1
-%section.productbrnd
-  %h2.kategorihead ピックアップブランド
-  .productbox
-    .productboxhead
-      = link_to "#" do
-        %h3.title アーカイバ
-  .productlists
-    - @products.each do |product|
-      .Products
-        = link_to product_path(product.id), class: 'Product' do
-          = image_tag @product_images.find_by(product_id: product.id).image, class: 'ItemImage'
-          .ItemDetail
-            .ItemDetail__Name
-              %h3
-                = product.name
-            .ItemDetail__Details
-              .Price
-                = product.price
-                %p (税込)
-              .Favorites
-                = icon('fas', 'star')
-                1

--- a/app/views/products/_main.html.haml
+++ b/app/views/products/_main.html.haml
@@ -84,8 +84,9 @@
                     = product.name
                 .ItemDetail__Details
                   .Price
-                    = product.price
+                    = "#{product.price}円"
                     %p (税込)
+                    -# ↑表記が確定したら繋げる
                   .Favorites
                     = icon('fas', 'star')
                     1
@@ -99,8 +100,9 @@
                     = product.name
                 .ItemDetail__Details
                   .Price
-                    = product.price
+                    = "#{product.price}円"
                     %p (税込)
+                    -# ↑表記が確定したら繋げる
                   .Favorites
                     = icon('fas', 'star')
                     1

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -67,7 +67,11 @@
             = link_to "#", class: 'InappropriateProductReporting__Btn' do
               = icon('fas', 'flag')
               不適切な商品の通報
-      - if user_signed_in? && current_user.id == @product.user_id
+      - if @purchase_history
+        .SoldOutBox
+          .SoldOutBox__Msg
+            売り切れました
+      - elsif user_signed_in? && current_user.id == @product.user_id
         .EditBox
           = link_to "#", class: 'EditBox__Btn EditBox__Btn--EditBtn' do
             商品の編集

--- a/db/migrate/20201201154416_create_purchase_histories.rb
+++ b/db/migrate/20201201154416_create_purchase_histories.rb
@@ -1,0 +1,8 @@
+class CreatePurchaseHistories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :purchase_histories do |t|
+      t.references :product, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_203034) do
+ActiveRecord::Schema.define(version: 2020_12_01_154416) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "last_name", null: false
@@ -80,6 +80,13 @@ ActiveRecord::Schema.define(version: 2020_11_12_203034) do
     t.index ["user_id"], name: "index_products_on_user_id"
   end
 
+  create_table "purchase_histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "product_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["product_id"], name: "index_purchase_histories_on_product_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", default: "", null: false
@@ -99,4 +106,5 @@ ActiveRecord::Schema.define(version: 2020_11_12_203034) do
   add_foreign_key "product_images", "products"
   add_foreign_key "products", "brands"
   add_foreign_key "products", "users"
+  add_foreign_key "purchase_histories", "products"
 end

--- a/test/fixtures/purchase_histories.yml
+++ b/test/fixtures/purchase_histories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/purchase_history_test.rb
+++ b/test/models/purchase_history_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PurchaseHistoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
トップページに出品した商品一覧が表示される様に実装。また、購入履歴テーブルを作成し、このテーブルに入っている商品は、商品一覧で「SOLDOUT」の表記が付き、売り切れた商品であることがわかる様に実装、及び、売り切れた商品の商品詳細ページへ遷移すると、購入画面へ遷移するボタンの場所に「売り切れました」と表示され、購入ができない様に実装した。

# Why
ユーザーが出品商品を閲覧できる様にする為。また、閲覧の際に、売り切れた商品が一目でわかる様にする為。

### `スクショ`
①商品一覧表示＆売り切れている商品には「SOLDOUT」の表記が付く。
https://gyazo.com/926bb3fb5b7ffce8239f970cfc753d51

②「SOLDOUT」の表記が付いた商品の詳細ページへ遷移しても購入できない様になっている。
https://gyazo.com/16d3af50433974a7eea9161c63cf72ca